### PR TITLE
fix(cloudflare): fix F5 session loss by routing data API paths to backend only when Bearer token present

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,20 +1,32 @@
 const BACKEND_URL = 'https://interview-hub-backend-qeczodae3q-rj.a.run.app';
 const FRONTEND_URL = 'https://interview-hub-frontend-qeczodae3q-rj.a.run.app';
 
-const BACKEND_PREFIXES = [
+// These paths always go to the backend regardless of headers (no Angular SPA routes conflict).
+const ALWAYS_BACKEND_PREFIXES = [
   '/auth/google',
   '/auth/token',
-  '/interviews',
-  '/shadowing-requests',
   '/actuator',
 ];
+
+// These paths share the same prefix as Angular SPA routes (/interviews, /interviews/:id).
+// Route to backend only when the request carries a Bearer token (XHR from Angular).
+// Browser navigations (F5, direct URL) have no Bearer and must reach the frontend SPA.
+const BEARER_BACKEND_PREFIXES = [
+  '/interviews',
+  '/shadowing-requests',
+];
+
+function matchesPrefix(pathname, prefixes) {
+  return prefixes.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
 
 export default {
   async fetch(request) {
     const url = new URL(request.url);
-    const isBackend = BACKEND_PREFIXES.some(
-      (p) => url.pathname === p || url.pathname.startsWith(p + '/')
-    );
+    const hasBearer = (request.headers.get('Authorization') || '').startsWith('Bearer ');
+    const isBackend =
+      matchesPrefix(url.pathname, ALWAYS_BACKEND_PREFIXES) ||
+      (hasBearer && matchesPrefix(url.pathname, BEARER_BACKEND_PREFIXES));
     const target = (isBackend ? BACKEND_URL : FRONTEND_URL) + url.pathname + url.search;
     return fetch(target, {
       method: request.method,


### PR DESCRIPTION
## Summary

- **Root cause:** The Angular SPA has routes `/interviews` and `/interviews/:id`. On F5 (or direct URL navigation), the browser sends a GET with no `Authorization` header. The old Worker matched the `/interviews/` prefix and forwarded the request to the backend. The backend required auth and returned 401 — the Angular app never loaded, making it look like the session was lost.
- **Fix:** Split backend prefixes into two groups:
  - `ALWAYS_BACKEND_PREFIXES` (`/auth/google`, `/auth/token`, `/actuator`) — always go to backend, no conflict with SPA routes.
  - `BEARER_BACKEND_PREFIXES` (`/interviews`, `/shadowing-requests`) — go to backend **only if `Authorization: Bearer` is present** (XHR from Angular app). Browser navigations fall through to the frontend SPA, which serves `index.html` and lets Angular's router handle them normally.

## Test plan

- [ ] F5 from `/interviews` → app loads and shows the interviews list (no 401)
- [ ] F5 from `/interviews/:id` → app loads and shows the interview detail (no 401)
- [ ] Angular HTTP calls to `/interviews` still reach the backend (Bearer header present)
- [ ] OAuth login flow (`/auth/google`) still works (always routed to backend)
- [ ] Health check (`/actuator/health`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)