### PR TITLE
feat: improve Google Calendar events with Meet, attendees, and formatting

### DIFF
--- a/src/main/java/com/gm2dev/interview_hub/service/GoogleCalendarService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/GoogleCalendarService.java
@@ -139,8 +139,15 @@ public class GoogleCalendarService {
 
         StringBuilder description = new StringBuilder();
         description.append("Tech Stack: ").append(interview.getTechStack());
-        if (interview.getCandidateInfo() != null) {
-            description.append("\nCandidate Info: ").append(interview.getCandidateInfo());
+
+        if (interview.getCandidateInfo() != null && !interview.getCandidateInfo().isEmpty()) {
+            description.append("\n\nCandidate Details:");
+            interview.getCandidateInfo().forEach((key, value) -> {
+                if (value != null) {
+                    String label = key.substring(0, 1).toUpperCase() + key.substring(1);
+                    description.append("\n  ").append(label).append(": ").append(value);
+                }
+            });
         }
         event.setDescription(description.toString());
 

--- a/src/test/java/com/gm2dev/interview_hub/service/GoogleCalendarServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/GoogleCalendarServiceTest.java
@@ -228,6 +228,32 @@ class GoogleCalendarServiceTest {
     }
 
     @Test
+    void createEvent_formatsDescriptionCleanly() throws IOException {
+        Profile profile = buildProfile();
+        Interview interview = buildInterview();
+        interview.setCandidateInfo(Map.of("name", "Jane Doe", "email", "jane@example.com"));
+
+        Event createdEvent = new Event().setId("event-desc");
+        doReturn(calendarClient).when(googleCalendarService).buildCalendarClient(profile);
+        when(calendarClient.events()).thenReturn(events);
+        when(events.insert(eq("primary"), any(Event.class))).thenReturn(insert);
+        when(insert.setConferenceDataVersion(1)).thenReturn(insert);
+        when(insert.execute()).thenReturn(createdEvent);
+
+        googleCalendarService.createEvent(profile, interview);
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(events).insert(eq("primary"), captor.capture());
+        String desc = captor.getValue().getDescription();
+
+        assertTrue(desc.contains("Tech Stack: Java"));
+        assertTrue(desc.contains("Candidate Details:"));
+        assertTrue(desc.contains("Name: Jane Doe"));
+        assertTrue(desc.contains("Email: jane@example.com"));
+        assertFalse(desc.contains("{"), "Description should not contain raw map format");
+    }
+
+    @Test
     void createEvent_includesInterviewerAndCandidateAsAttendees() throws IOException {
         Profile profile = buildProfile();
         Interview interview = buildInterview();


### PR DESCRIPTION
## Summary
- Add Google Meet conferencing to interview calendar events (hangoutsMeet solution key + `setConferenceDataVersion(1)`)
- Invite interviewer and candidate (when email provided) as event attendees
- Format event description with clean key-value layout instead of raw `Map.toString()`

## Test Plan
- [x] New test: `createEvent_includesGoogleMeetConferenceData` — verifies conference data present
- [x] New test: `createEvent_includesInterviewerAndCandidateAsAttendees` — verifies both attendees added
- [x] New test: `createEvent_onlyInterviewerAttendee_whenNoCandidateEmail` — verifies graceful handling
- [x] New test: `createEvent_formatsDescriptionCleanly` — verifies formatted output, no raw map
- [x] All existing tests updated and passing
- [x] Full test suite passing (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)