### PR TITLE
ci: add PR pipeline with backend and frontend checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Run tests and verify coverage
+        run: ./gradlew check
+
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html/
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun run test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr.yml` triggered on PRs targeting `main`
- **Backend job**: runs `./gradlew check` (tests + JaCoCo ≥80% branch coverage), uploads HTML report as artifact
- **Frontend job**: runs `bun install && bun run test` (Vitest)
- Both jobs run in parallel on `ubuntu-latest`

## Test plan
- [ ] Open this PR and verify both `backend` and `frontend` jobs appear and pass
- [ ] Confirm JaCoCo HTML report is uploaded as artifact on the backend job

🤖 Generated with [Claude Code](https://claude.com/claude-code)