### PR TITLE
test: achieve 100% branch coverage on hand-written code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,8 @@ jacocoTestReport {
 		classDirectories.setFrom(files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: [
 				'**/InterviewHubApplication.class',
-				'**/GoogleCalendarService.class'
+				'**/GoogleCalendarService.class',
+				'**/*MapperImpl.class'
 			])
 		}))
 	}
@@ -99,7 +100,8 @@ jacocoTestCoverageVerification {
 		classDirectories.setFrom(files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: [
 				'**/InterviewHubApplication.class',
-				'**/GoogleCalendarService.class'
+				'**/GoogleCalendarService.class',
+				'**/*MapperImpl.class'
 			])
 		}))
 	}
@@ -107,7 +109,7 @@ jacocoTestCoverageVerification {
 		rule {
 			limit {
 				counter = 'BRANCH'
-				minimum = 0.80
+				minimum = 0.95
 			}
 		}
 	}

--- a/src/test/java/com/gm2dev/interview_hub/service/InterviewServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/InterviewServiceTest.java
@@ -356,6 +356,36 @@ class InterviewServiceTest {
     }
 
     @Test
+    void updateInterview_withTalentAcquisition_setsRelation() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "upd-ta@example.com", "interviewer", null);
+        profileRepository.save(interviewer);
+
+        UUID taId = UUID.randomUUID();
+        Profile ta = new Profile(taId, "upd-ta-role@example.com", "interviewer", null);
+        profileRepository.save(ta);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
+
+        Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+        Instant newEnd = newStart.plus(1, ChronoUnit.HOURS);
+
+        UpdateInterviewRequest updateRequest = new UpdateInterviewRequest(
+                candidate.getId(), taId, "Kotlin", newStart, newEnd, InterviewStatus.SCHEDULED);
+
+        Interview updated = interviewService.updateInterview(created.getId(), updateRequest, profileId);
+
+        assertNotNull(updated.getTalentAcquisition());
+        assertEquals(taId, updated.getTalentAcquisition().getId());
+    }
+
+    @Test
     void createInterview_withTalentAcquisition_setsRelation() {
         UUID profileId = UUID.randomUUID();
         Profile interviewer = new Profile(profileId, "ta-test@example.com", "interviewer", null);


### PR DESCRIPTION
## Summary
- Add missing test for `InterviewService.updateInterview` with a talent acquisition ID, covering the last uncovered branch in application code
- Exclude auto-generated MapStruct `*MapperImpl` classes from JaCoCo coverage checks (same pattern as existing `InterviewHubApplication` and `GoogleCalendarService` exclusions)
- Raise branch coverage minimum threshold from 0.80 to 0.95

## Test plan
- [x] `./gradlew test` — all tests pass
- [x] `./gradlew jacocoTestCoverageVerification` — passes at 100% branch coverage (excluding generated code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)