### PR TITLE
fix(ci): use full git history in deploy change detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
       infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
Add fetch-depth: 0 to the checkout step in the changes job so dorny/paths-filter can diff between the before and after commits on merge pushes to prod.