### PR TITLE
feat(ci): add manual full deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,12 @@ name: Deploy to GCP
 on:
   push:
     branches: [prod]
+  workflow_dispatch:
+    inputs:
+      force_full_deploy:
+        description: 'Deploy all services (skip change detection)'
+        type: boolean
+        default: true
 
 env:
   GCP_REGION: southamerica-east1
@@ -15,9 +21,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      infra: ${{ steps.filter.outputs.infra }}
+      backend: ${{ inputs.force_full_deploy == true && 'true' || steps.filter.outputs.backend }}
+      frontend: ${{ inputs.force_full_deploy == true && 'true' || steps.filter.outputs.frontend }}
+      infra: ${{ inputs.force_full_deploy == true && 'true' || steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the deploy workflow with a `force_full_deploy` checkbox
- When checked, all change detection outputs are forced to `true`, deploying backend + frontend + infra
- Normal pushes to `prod` continue using paths-filter as before

## Test plan
- [ ] After merging, go to Actions → Deploy to GCP → Run workflow → select `prod` branch → check the box → Run
- [ ] Verify all three services are built and deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)