### PR TITLE
fix: prevent DB connection pool exhaustion on Supabase

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,10 +4,16 @@ spring:
     name: interview-hub
 
   datasource:
-    url: ${DB_URL:jdbc:postgresql://db.${SUPABASE_IDENTIFIER}.supabase.co:5432/postgres}
+    url: ${DB_URL:jdbc:postgresql://aws-1-sa-east-1.pooler.supabase.com:6543/postgres}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:3}
+      minimum-idle: 1
+      connection-timeout: 20000
+      data-source-properties:
+        prepareThreshold: 0
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- Limit HikariCP pool to **3 connections** per Cloud Run instance (down from default 10), configurable via `HIKARI_MAX_POOL_SIZE` env var
- Switch default `DB_URL` to Supabase **transaction pooler** (port 6543) — more efficient for serverless workloads
- Disable prepared statements (`prepareThreshold=0`) required for PgBouncer transaction mode compatibility

## Context
The backend was returning 503 due to `MaxClientsInSessionMode: max clients reached`. Multiple Cloud Run instances from PR pipelines and reviewer agents were exhausting Supabase's session-mode connection limit.

## Action required after merge
Update the `DB_URL` env var in Cloud Run to use the transaction pooler URL (port `6543`).

## Test plan
- [ ] Verify backend starts successfully with new pool settings
- [ ] Confirm `/actuator/health` returns 200
- [ ] Run concurrent requests to ensure pool size is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)