### PR TITLE
Deploy: DB connection pool fix

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,10 +4,16 @@ spring:
     name: interview-hub
 
   datasource:
-    url: ${DB_URL:jdbc:postgresql://db.${SUPABASE_IDENTIFIER}.supabase.co:5432/postgres}
+    url: ${DB_URL:jdbc:postgresql://aws-1-sa-east-1.pooler.supabase.com:6543/postgres}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:3}
+      minimum-idle: 1
+      connection-timeout: 20000
+      data-source-properties:
+        prepareThreshold: 0
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- Merge main → prod to deploy connection pool exhaustion fix

## Changes
- HikariCP pool limited to 3 connections per instance (configurable via `HIKARI_MAX_POOL_SIZE`)
- Default DB URL switched to Supabase transaction pooler (port 6543)
- Disabled prepared statements for PgBouncer transaction mode compatibility
- DB_URL secret already updated in Secret Manager (version 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)