### PR TITLE
fix: disable mail health indicator for Cloud Run deploy

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,11 @@ app:
   google-service-account:
     key-json: ${GOOGLE_SERVICE_ACCOUNT_KEY:}
 
+management:
+  health:
+    mail:
+      enabled: false
+
 logging:
   level:
     com.gm2dev.interview_hub: DEBUG


### PR DESCRIPTION
## Summary
- Disables the Spring Boot mail health indicator that was causing `/actuator/health` to return DOWN
- The mail health check tries to connect to the SMTP server, but `MAIL_*` env vars are not yet configured in Cloud Run secrets
- This was the second failure cause after the missing DB migration (already applied)

## Root cause
PR #24 added `spring-boot-starter-mail` which auto-registers a `MailHealthIndicator`. Cloud Run's startup probe hits `/actuator/health`, which includes the mail check, which fails → app never passes health check → startup probe fails → deploy fails.

## Test plan
- [x] DB migration for `email_verified` and `verification_tokens` already applied to prod Supabase
- [x] DB migration for admin seed already applied
- [ ] Verify deploy succeeds after merge
- [ ] Verify `/actuator/health` returns UP

🤖 Generated with [Claude Code](https://claude.com/claude-code)