### PR TITLE
Release: calendar fixes, Resend notifications, auth interceptor

### DIFF
--- a/src/main/java/com/gm2dev/interview_hub/service/EmailService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/EmailService.java
@@ -6,6 +6,7 @@ import com.resend.services.emails.model.CreateEmailOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
 
 @Service
 @Slf4j
@@ -50,6 +51,49 @@ public class EmailService {
                 + "<p>Your temporary password is: <strong>" + temporaryPassword + "</strong></p>"
                 + "<p>Please log in and change your password.</p>";
         sendHtmlEmail(toEmail, subject, body);
+    }
+
+    public void sendInterviewInviteEmail(String toEmail, String summary, String startTime, String endTime, String meetLink) {
+        String safeSummary = HtmlUtils.htmlEscape(summary);
+        String subject = "Interview Hub — Interview Scheduled: " + summary;
+        String body = "<h2>Interview Scheduled</h2>"
+                + "<p><strong>" + safeSummary + "</strong></p>"
+                + "<p>Start: " + HtmlUtils.htmlEscape(startTime) + "</p>"
+                + "<p>End: " + HtmlUtils.htmlEscape(endTime) + "</p>"
+                + (meetLink != null ? "<p>Google Meet: <a href=\"" + HtmlUtils.htmlEscape(meetLink) + "\">" + HtmlUtils.htmlEscape(meetLink) + "</a></p>" : "")
+                + "<p>This event has been added to the shared interview calendar.</p>";
+        sendHtmlEmailQuietly(toEmail, subject, body);
+    }
+
+    public void sendInterviewUpdateEmail(String toEmail, String summary, String startTime, String endTime) {
+        String safeSummary = HtmlUtils.htmlEscape(summary);
+        String subject = "Interview Hub — Interview Updated: " + summary;
+        String body = "<h2>Interview Updated</h2>"
+                + "<p><strong>" + safeSummary + "</strong></p>"
+                + "<p>New Start: " + HtmlUtils.htmlEscape(startTime) + "</p>"
+                + "<p>New End: " + HtmlUtils.htmlEscape(endTime) + "</p>"
+                + "<p>The calendar event has been updated.</p>";
+        sendHtmlEmailQuietly(toEmail, subject, body);
+    }
+
+    public void sendInterviewCancellationEmail(String toEmail, String summary) {
+        String safeSummary = HtmlUtils.htmlEscape(summary);
+        String subject = "Interview Hub — Interview Cancelled: " + summary;
+        String body = "<h2>Interview Cancelled</h2>"
+                + "<p><strong>" + safeSummary + "</strong></p>"
+                + "<p>This interview has been cancelled and removed from the calendar.</p>";
+        sendHtmlEmailQuietly(toEmail, subject, body);
+    }
+
+    public void sendShadowingApprovedEmail(String toEmail, String summary, String startTime, String endTime) {
+        String safeSummary = HtmlUtils.htmlEscape(summary);
+        String subject = "Interview Hub — Shadowing Approved: " + summary;
+        String body = "<h2>Shadowing Request Approved</h2>"
+                + "<p><strong>" + safeSummary + "</strong></p>"
+                + "<p>Start: " + HtmlUtils.htmlEscape(startTime) + "</p>"
+                + "<p>End: " + HtmlUtils.htmlEscape(endTime) + "</p>"
+                + "<p>You have been added to the calendar event as an attendee.</p>";
+        sendHtmlEmailQuietly(toEmail, subject, body);
     }
 
     private void sendHtmlEmail(String to, String subject, String htmlBody) {

--- a/src/main/java/com/gm2dev/interview_hub/service/GoogleCalendarService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/GoogleCalendarService.java
@@ -29,23 +29,25 @@ import java.util.UUID;
 @Slf4j
 public class GoogleCalendarService {
 
+    public record CalendarEventResult(String eventId, String meetLink) {}
+
     private final GoogleServiceAccountProperties serviceAccountProperties;
 
     public GoogleCalendarService(GoogleServiceAccountProperties serviceAccountProperties) {
         this.serviceAccountProperties = serviceAccountProperties;
     }
 
-    public String createEvent(Interview interview) throws IOException {
+    public CalendarEventResult createEvent(Interview interview) throws IOException {
         Calendar calendar = buildCalendarClient();
         String calendarId = serviceAccountProperties.getCalendarId();
         Event event = buildEvent(interview);
 
         Event created = calendar.events().insert(calendarId, event)
                 .setConferenceDataVersion(1)
-                .setSendUpdates("all")
+                .setSendUpdates("none")
                 .execute();
         log.debug("Created Google Calendar event: {}", created.getId());
-        return created.getId();
+        return new CalendarEventResult(created.getId(), created.getHangoutLink());
     }
 
     public void updateEvent(Interview interview) throws IOException {
@@ -55,7 +57,7 @@ public class GoogleCalendarService {
 
         calendar.events().update(calendarId, interview.getGoogleEventId(), event)
                 .setConferenceDataVersion(1)
-                .setSendUpdates("all")
+                .setSendUpdates("none")
                 .execute();
         log.debug("Updated Google Calendar event: {}", interview.getGoogleEventId());
     }
@@ -64,7 +66,9 @@ public class GoogleCalendarService {
         Calendar calendar = buildCalendarClient();
         String calendarId = serviceAccountProperties.getCalendarId();
 
-        calendar.events().delete(calendarId, googleEventId).execute();
+        calendar.events().delete(calendarId, googleEventId)
+                .setSendUpdates("none")
+                .execute();
         log.debug("Deleted Google Calendar event: {}", googleEventId);
     }
 
@@ -83,7 +87,7 @@ public class GoogleCalendarService {
 
         Event patch = new Event().setAttendees(attendees);
         calendar.events().patch(calendarId, googleEventId, patch)
-                .setSendUpdates("all")
+                .setSendUpdates("none")
                 .execute();
 
         log.debug("Added attendee {} to event {}", attendeeEmail, googleEventId);

--- a/src/main/java/com/gm2dev/interview_hub/service/InterviewService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/InterviewService.java
@@ -20,6 +20,9 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 @Service
@@ -27,10 +30,15 @@ import java.util.UUID;
 @Slf4j
 public class InterviewService {
 
+    static final DateTimeFormatter EMAIL_DATE_FMT =
+            DateTimeFormatter.ofPattern("MMMM d, yyyy 'at' h:mm a z")
+                    .withZone(ZoneId.of("UTC"));
+
     private final InterviewRepository interviewRepository;
     private final ProfileRepository profileRepository;
     private final CandidateRepository candidateRepository;
     private final GoogleCalendarService googleCalendarService;
+    private final EmailService emailService;
     private final InterviewMapper interviewMapper;
 
     @Transactional
@@ -59,13 +67,17 @@ public class InterviewService {
 
         interview = interviewRepository.save(interview);
 
+        String meetLink = null;
         try {
-            String googleEventId = googleCalendarService.createEvent(interview);
-            interview.setGoogleEventId(googleEventId);
+            GoogleCalendarService.CalendarEventResult calendarResult = googleCalendarService.createEvent(interview);
+            interview.setGoogleEventId(calendarResult.eventId());
+            meetLink = calendarResult.meetLink();
             interview = interviewRepository.save(interview);
         } catch (Exception e) {
             log.warn("Failed to create Google Calendar event for interview {}: {}", interview.getId(), e.getMessage());
         }
+
+        sendInviteEmails(interview, meetLink);
 
         return interview;
     }
@@ -112,6 +124,8 @@ public class InterviewService {
             }
         }
 
+        sendUpdateEmails(interview);
+
         return interview;
     }
 
@@ -130,6 +144,60 @@ public class InterviewService {
             }
         }
 
+        sendCancellationEmails(interview);
+
         interviewRepository.delete(interview);
+    }
+
+    static String buildSummary(Interview interview) {
+        String candidateName = interview.getCandidate() != null && interview.getCandidate().getName() != null
+                ? interview.getCandidate().getName() : "Unknown";
+        return interview.getTechStack() + " Interview - " + candidateName;
+    }
+
+    private void sendInviteEmails(Interview interview, String meetLink) {
+        String summary = buildSummary(interview);
+        String start = EMAIL_DATE_FMT.format(interview.getStartTime());
+        String end = EMAIL_DATE_FMT.format(interview.getEndTime());
+
+        emailService.sendInterviewInviteEmail(interview.getInterviewer().getEmail(), summary, start, end, meetLink);
+
+        if (interview.getCandidate().getEmail() != null) {
+            emailService.sendInterviewInviteEmail(interview.getCandidate().getEmail(), summary, start, end, meetLink);
+        }
+
+        if (interview.getTalentAcquisition() != null) {
+            emailService.sendInterviewInviteEmail(interview.getTalentAcquisition().getEmail(), summary, start, end, meetLink);
+        }
+    }
+
+    private void sendUpdateEmails(Interview interview) {
+        String summary = buildSummary(interview);
+        String start = EMAIL_DATE_FMT.format(interview.getStartTime());
+        String end = EMAIL_DATE_FMT.format(interview.getEndTime());
+
+        emailService.sendInterviewUpdateEmail(interview.getInterviewer().getEmail(), summary, start, end);
+
+        if (interview.getCandidate().getEmail() != null) {
+            emailService.sendInterviewUpdateEmail(interview.getCandidate().getEmail(), summary, start, end);
+        }
+
+        if (interview.getTalentAcquisition() != null) {
+            emailService.sendInterviewUpdateEmail(interview.getTalentAcquisition().getEmail(), summary, start, end);
+        }
+    }
+
+    private void sendCancellationEmails(Interview interview) {
+        String summary = buildSummary(interview);
+
+        emailService.sendInterviewCancellationEmail(interview.getInterviewer().getEmail(), summary);
+
+        if (interview.getCandidate().getEmail() != null) {
+            emailService.sendInterviewCancellationEmail(interview.getCandidate().getEmail(), summary);
+        }
+
+        if (interview.getTalentAcquisition() != null) {
+            emailService.sendInterviewCancellationEmail(interview.getTalentAcquisition().getEmail(), summary);
+        }
     }
 }

--- a/src/main/java/com/gm2dev/interview_hub/service/ShadowingRequestService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/ShadowingRequestService.java
@@ -26,6 +26,7 @@ public class ShadowingRequestService {
     private final InterviewRepository interviewRepository;
     private final ProfileRepository profileRepository;
     private final GoogleCalendarService googleCalendarService;
+    private final EmailService emailService;
 
     @Transactional
     public ShadowingRequest requestShadowing(UUID interviewId, UUID shadowerId) {
@@ -79,6 +80,14 @@ public class ShadowingRequestService {
                         request.getShadower().getEmail(), interview.getGoogleEventId(), e.getMessage());
             }
         }
+
+        String summary = InterviewService.buildSummary(interview);
+
+        emailService.sendShadowingApprovedEmail(
+                request.getShadower().getEmail(),
+                summary,
+                InterviewService.EMAIL_DATE_FMT.format(interview.getStartTime()),
+                InterviewService.EMAIL_DATE_FMT.format(interview.getEndTime()));
 
         return saved;
     }

--- a/src/test/java/com/gm2dev/interview_hub/controller/InterviewControllerTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/controller/InterviewControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -95,15 +96,17 @@ class InterviewControllerTest {
         Interview interview = buildInterview();
         when(interviewService.createInterview(any(CreateInterviewRequest.class))).thenReturn(interview);
 
+        Instant futureStart = Instant.now().plus(30, ChronoUnit.DAYS);
+        Instant futureEnd = futureStart.plus(1, ChronoUnit.HOURS);
         String body = """
                 {
                     "interviewerId": "%s",
                     "candidateId": "%s",
                     "techStack": "Java",
-                    "startTime": "2026-03-15T10:00:00Z",
-                    "endTime": "2026-03-15T11:00:00Z"
+                    "startTime": "%s",
+                    "endTime": "%s"
                 }
-                """.formatted(UUID.randomUUID(), UUID.randomUUID());
+                """.formatted(UUID.randomUUID(), UUID.randomUUID(), futureStart, futureEnd);
 
         mockMvc.perform(post("/api/interviews")
                         .with(jwt())

--- a/src/test/java/com/gm2dev/interview_hub/service/EmailServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/EmailServiceTest.java
@@ -86,6 +86,81 @@ class EmailServiceTest {
     }
 
     @Test
+    void sendInterviewInviteEmail_sendsEmail() throws ResendException {
+        when(resend.emails()).thenReturn(resendEmails);
+        when(resendEmails.send(any(CreateEmailOptions.class))).thenReturn(createEmailResponse);
+
+        emailService.sendInterviewInviteEmail(
+                "attendee@example.com",
+                "Java Interview - Jane Doe",
+                "2026-03-20T10:00:00Z",
+                "2026-03-20T11:00:00Z",
+                "https://meet.google.com/abc-defg-hij"
+        );
+
+        verify(resendEmails).send(any(CreateEmailOptions.class));
+    }
+
+    @Test
+    void sendInterviewInviteEmail_withNullMeetLink_sendsEmail() throws ResendException {
+        when(resend.emails()).thenReturn(resendEmails);
+        when(resendEmails.send(any(CreateEmailOptions.class))).thenReturn(createEmailResponse);
+
+        emailService.sendInterviewInviteEmail(
+                "attendee@example.com",
+                "Java Interview - Jane Doe",
+                "2026-03-20T10:00:00Z",
+                "2026-03-20T11:00:00Z",
+                null
+        );
+
+        verify(resendEmails).send(any(CreateEmailOptions.class));
+    }
+
+    @Test
+    void sendInterviewUpdateEmail_sendsEmail() throws ResendException {
+        when(resend.emails()).thenReturn(resendEmails);
+        when(resendEmails.send(any(CreateEmailOptions.class))).thenReturn(createEmailResponse);
+
+        emailService.sendInterviewUpdateEmail(
+                "attendee@example.com",
+                "Java Interview - Jane Doe",
+                "2026-03-21T10:00:00Z",
+                "2026-03-21T11:00:00Z"
+        );
+
+        verify(resendEmails).send(any(CreateEmailOptions.class));
+    }
+
+    @Test
+    void sendInterviewCancellationEmail_sendsEmail() throws ResendException {
+        when(resend.emails()).thenReturn(resendEmails);
+        when(resendEmails.send(any(CreateEmailOptions.class))).thenReturn(createEmailResponse);
+
+        emailService.sendInterviewCancellationEmail(
+                "attendee@example.com",
+                "Java Interview - Jane Doe"
+        );
+
+        verify(resendEmails).send(any(CreateEmailOptions.class));
+    }
+
+    @Test
+    void sendShadowingApprovedEmail_sendsEmail() throws ResendException {
+        when(resend.emails()).thenReturn(resendEmails);
+        when(resendEmails.send(any(CreateEmailOptions.class))).thenReturn(createEmailResponse);
+
+        emailService.sendShadowingApprovedEmail(
+                "shadower@example.com",
+                "Java Interview - Jane Doe",
+                "2026-03-20T10:00:00Z",
+                "2026-03-20T11:00:00Z"
+        );
+
+        verify(resendEmails).send(any(CreateEmailOptions.class));
+    }
+
+    @Test
     void sendPasswordResetEmail_whenResendFails_doesNotThrow() throws ResendException {
         when(resend.emails()).thenReturn(resendEmails);
         when(resendEmails.send(any(CreateEmailOptions.class)))

--- a/src/test/java/com/gm2dev/interview_hub/service/GoogleCalendarServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/GoogleCalendarServiceTest.java
@@ -93,12 +93,12 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
-        String eventId = googleCalendarService.createEvent(interview);
+        GoogleCalendarService.CalendarEventResult result = googleCalendarService.createEvent(interview);
 
-        assertEquals("google-event-id-123", eventId);
+        assertEquals("google-event-id-123", result.eventId());
         verify(events).insert(eq("test-calendar-id"), any(Event.class));
     }
 
@@ -111,7 +111,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -128,7 +128,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -153,7 +153,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.update(eq("test-calendar-id"), eq("existing-event-id"), any(Event.class))).thenReturn(update);
         when(update.setConferenceDataVersion(1)).thenReturn(update);
-        when(update.setSendUpdates("all")).thenReturn(update);
+        when(update.setSendUpdates("none")).thenReturn(update);
         when(update.execute()).thenReturn(updatedEvent);
 
         googleCalendarService.updateEvent(interview);
@@ -166,10 +166,12 @@ class GoogleCalendarServiceTest {
         doReturn(calendarClient).when(googleCalendarService).buildCalendarClient();
         when(calendarClient.events()).thenReturn(events);
         when(events.delete("test-calendar-id", "event-to-delete")).thenReturn(deleteOp);
+        when(deleteOp.setSendUpdates("none")).thenReturn(deleteOp);
 
         googleCalendarService.deleteEvent("event-to-delete");
 
         verify(events).delete("test-calendar-id", "event-to-delete");
+        verify(deleteOp).setSendUpdates("none");
         verify(deleteOp).execute();
     }
 
@@ -183,7 +185,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -208,7 +210,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -228,7 +230,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -253,7 +255,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -281,7 +283,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);
@@ -307,7 +309,7 @@ class GoogleCalendarServiceTest {
         when(events.get("test-calendar-id", "event-with-attendees")).thenReturn(getOp);
         when(getOp.execute()).thenReturn(existingEvent);
         when(events.patch(eq("test-calendar-id"), eq("event-with-attendees"), any(Event.class))).thenReturn(patchOp);
-        when(patchOp.setSendUpdates("all")).thenReturn(patchOp);
+        when(patchOp.setSendUpdates("none")).thenReturn(patchOp);
         when(patchOp.execute()).thenReturn(patchedEvent);
 
         googleCalendarService.addAttendee("event-with-attendees", "shadower@gm2dev.com");
@@ -332,7 +334,7 @@ class GoogleCalendarServiceTest {
         when(events.get("test-calendar-id", "event-null-attendees")).thenReturn(getOp);
         when(getOp.execute()).thenReturn(existingEvent);
         when(events.patch(eq("test-calendar-id"), eq("event-null-attendees"), any(Event.class))).thenReturn(patchOp);
-        when(patchOp.setSendUpdates("all")).thenReturn(patchOp);
+        when(patchOp.setSendUpdates("none")).thenReturn(patchOp);
         when(patchOp.execute()).thenReturn(patchedEvent);
 
         googleCalendarService.addAttendee("event-null-attendees", "new@gm2dev.com");
@@ -353,7 +355,7 @@ class GoogleCalendarServiceTest {
         when(calendarClient.events()).thenReturn(events);
         when(events.insert(eq("test-calendar-id"), any(Event.class))).thenReturn(insert);
         when(insert.setConferenceDataVersion(1)).thenReturn(insert);
-        when(insert.setSendUpdates("all")).thenReturn(insert);
+        when(insert.setSendUpdates("none")).thenReturn(insert);
         when(insert.execute()).thenReturn(createdEvent);
 
         googleCalendarService.createEvent(interview);

--- a/src/test/java/com/gm2dev/interview_hub/service/InterviewServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/InterviewServiceTest.java
@@ -28,7 +28,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
@@ -51,6 +51,9 @@ class InterviewServiceTest {
 
     @MockitoBean
     private GoogleCalendarService googleCalendarService;
+
+    @MockitoBean
+    private EmailService emailService;
 
     private Candidate createTestCandidate() {
         return candidateRepository.save(new Candidate(null, "Test Candidate", "candidate@example.com", null, null, null));
@@ -237,7 +240,7 @@ class InterviewServiceTest {
         Instant end = start.plus(1, ChronoUnit.HOURS);
 
         when(googleCalendarService.createEvent(any(Interview.class)))
-                .thenReturn("gcal-event-123");
+                .thenReturn(new GoogleCalendarService.CalendarEventResult("gcal-event-123", null));
 
         Interview result = interviewService.createInterview(
                 new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
@@ -278,7 +281,7 @@ class InterviewServiceTest {
         Instant end = start.plus(1, ChronoUnit.HOURS);
 
         when(googleCalendarService.createEvent(any(Interview.class)))
-                .thenReturn("gcal-upd-event");
+                .thenReturn(new GoogleCalendarService.CalendarEventResult("gcal-upd-event", null));
 
         Interview created = interviewService.createInterview(
                 new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
@@ -304,7 +307,7 @@ class InterviewServiceTest {
         Instant end = start.plus(1, ChronoUnit.HOURS);
 
         when(googleCalendarService.createEvent(any(Interview.class)))
-                .thenReturn("gcal-del-event");
+                .thenReturn(new GoogleCalendarService.CalendarEventResult("gcal-del-event", null));
 
         Interview created = interviewService.createInterview(
                 new CreateInterviewRequest(profileId, candidate.getId(), null, "Rust", start, end));
@@ -408,5 +411,249 @@ class InterviewServiceTest {
 
         assertNotNull(result.getTalentAcquisition());
         assertEquals(taId, result.getTalentAcquisition().getId());
+    }
+
+    @Test
+    void updateInterview_sendsUpdateEmailsToAttendees() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "upd-email@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
+
+        // Reset mock to ignore invite emails from createInterview
+        reset(emailService);
+
+        Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+        Instant newEnd = newStart.plus(1, ChronoUnit.HOURS);
+
+        interviewService.updateInterview(created.getId(), new UpdateInterviewRequest(
+                candidate.getId(), null, "Kotlin", newStart, newEnd, InterviewStatus.SCHEDULED), profileId);
+
+        String expectedSummary = "Kotlin Interview - Test Candidate";
+
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("upd-email@example.com"), eq(expectedSummary), anyString(), anyString());
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("candidate@example.com"), eq(expectedSummary), anyString(), anyString());
+    }
+
+    @Test
+    void deleteInterview_sendsCancellationEmailsToAttendees() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "del-email@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Rust", start, end));
+
+        // Reset mock to ignore invite emails from createInterview
+        reset(emailService);
+
+        interviewService.deleteInterview(created.getId(), profileId);
+
+        String expectedSummary = "Rust Interview - Test Candidate";
+
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("del-email@example.com"), eq(expectedSummary));
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("candidate@example.com"), eq(expectedSummary));
+    }
+
+    @Test
+    void createInterview_withCandidateWithoutEmail_sendsInviteOnlyToInterviewer() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "no-email-test@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, "No Email Candidate", null, null, null, null));
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
+
+        verify(emailService).sendInterviewInviteEmail(
+                eq("no-email-test@example.com"), anyString(), anyString(), anyString(), isNull());
+        verify(emailService, never()).sendInterviewInviteEmail(
+                eq((String) null), anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void createInterview_withCandidateWithoutName_usesUnknownInSummary() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "no-name-test@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, null, "noname@example.com", null, null, null));
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
+
+        verify(emailService).sendInterviewInviteEmail(
+                eq("no-name-test@example.com"), eq("Java Interview - Unknown"), anyString(), anyString(), isNull());
+    }
+
+    @Test
+    void updateInterview_withTalentAcquisition_sendsUpdateEmailsToAll() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "upd-ta-email@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        UUID taId = UUID.randomUUID();
+        Profile ta = new Profile(taId, "ta-upd-email@example.com", Role.interviewer);
+        profileRepository.save(ta);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), taId, "Java", start, end));
+
+        reset(emailService);
+
+        Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+        Instant newEnd = newStart.plus(1, ChronoUnit.HOURS);
+
+        interviewService.updateInterview(created.getId(), new UpdateInterviewRequest(
+                candidate.getId(), taId, "Kotlin", newStart, newEnd, InterviewStatus.SCHEDULED), profileId);
+
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("upd-ta-email@example.com"), anyString(), anyString(), anyString());
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("candidate@example.com"), anyString(), anyString(), anyString());
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("ta-upd-email@example.com"), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void deleteInterview_withTalentAcquisition_sendsCancellationEmailsToAll() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "del-ta-email@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        UUID taId = UUID.randomUUID();
+        Profile ta = new Profile(taId, "ta-del-email@example.com", Role.interviewer);
+        profileRepository.save(ta);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), taId, "Rust", start, end));
+
+        reset(emailService);
+
+        interviewService.deleteInterview(created.getId(), profileId);
+
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("del-ta-email@example.com"), anyString());
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("candidate@example.com"), anyString());
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("ta-del-email@example.com"), anyString());
+    }
+
+    @Test
+    void updateInterview_withCandidateWithoutEmail_skipsEmailToCandidate() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "upd-noemail@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, "No Email", null, null, null, null));
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Java", start, end));
+
+        reset(emailService);
+
+        Instant newStart = Instant.now().plus(2, ChronoUnit.DAYS);
+        Instant newEnd = newStart.plus(1, ChronoUnit.HOURS);
+
+        interviewService.updateInterview(created.getId(), new UpdateInterviewRequest(
+                candidate.getId(), null, "Kotlin", newStart, newEnd, InterviewStatus.SCHEDULED), profileId);
+
+        verify(emailService).sendInterviewUpdateEmail(
+                eq("upd-noemail@example.com"), anyString(), anyString(), anyString());
+        verify(emailService, times(1)).sendInterviewUpdateEmail(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void deleteInterview_withCandidateWithoutEmail_skipsEmailToCandidate() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "del-noemail@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, "No Email", null, null, null, null));
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        Interview created = interviewService.createInterview(
+                new CreateInterviewRequest(profileId, candidate.getId(), null, "Rust", start, end));
+
+        reset(emailService);
+
+        interviewService.deleteInterview(created.getId(), profileId);
+
+        verify(emailService).sendInterviewCancellationEmail(
+                eq("del-noemail@example.com"), anyString());
+        verify(emailService, times(1)).sendInterviewCancellationEmail(anyString(), anyString());
+    }
+
+    @Test
+    void createInterview_sendsInviteEmailsToAttendees() {
+        UUID profileId = UUID.randomUUID();
+        Profile interviewer = new Profile(profileId, "invite-test@example.com", Role.interviewer);
+        profileRepository.save(interviewer);
+
+        UUID taId = UUID.randomUUID();
+        Profile ta = new Profile(taId, "ta-invite@example.com", Role.interviewer);
+        profileRepository.save(ta);
+
+        Candidate candidate = createTestCandidate();
+
+        Instant start = Instant.now().plus(1, ChronoUnit.DAYS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+
+        CreateInterviewRequest request = new CreateInterviewRequest(
+                profileId, candidate.getId(), taId, "Java", start, end);
+
+        interviewService.createInterview(request);
+
+        String expectedSummary = "Java Interview - Test Candidate";
+
+        verify(emailService).sendInterviewInviteEmail(
+                eq("invite-test@example.com"), eq(expectedSummary), anyString(), anyString(), isNull());
+        verify(emailService).sendInterviewInviteEmail(
+                eq("candidate@example.com"), eq(expectedSummary), anyString(), anyString(), isNull());
+        verify(emailService).sendInterviewInviteEmail(
+                eq("ta-invite@example.com"), eq(expectedSummary), anyString(), anyString(), isNull());
     }
 }

--- a/src/test/java/com/gm2dev/interview_hub/service/ShadowingRequestServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/ShadowingRequestServiceTest.java
@@ -1,6 +1,7 @@
 package com.gm2dev.interview_hub.service;
 
 import com.gm2dev.interview_hub.domain.*;
+import com.gm2dev.interview_hub.repository.CandidateRepository;
 import com.gm2dev.interview_hub.repository.InterviewRepository;
 import com.gm2dev.interview_hub.repository.ProfileRepository;
 import com.gm2dev.interview_hub.repository.ShadowingRequestRepository;
@@ -20,6 +21,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @SpringBootTest
@@ -40,8 +44,14 @@ class ShadowingRequestServiceTest {
     @Autowired
     private ShadowingRequestRepository shadowingRequestRepository;
 
+    @Autowired
+    private CandidateRepository candidateRepository;
+
     @MockitoBean
     private GoogleCalendarService googleCalendarService;
+
+    @MockitoBean
+    private EmailService emailService;
 
     private Profile interviewer;
     private Profile shadower;
@@ -195,5 +205,52 @@ class ShadowingRequestServiceTest {
 
         assertThrows(AccessDeniedException.class,
                 () -> shadowingRequestService.rejectShadowingRequest(request.getId(), "reason", otherId));
+    }
+
+    @Test
+    void approveShadowingRequest_withCandidateWithoutName_usesUnknownInEmail() {
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, null, "noname@example.com", null, null, null));
+        interview.setCandidate(candidate);
+        interview = interviewRepository.save(interview);
+
+        ShadowingRequest request = shadowingRequestService.requestShadowing(interview.getId(), shadower.getId());
+        shadowingRequestService.approveShadowingRequest(request.getId(), interviewer.getId());
+
+        verify(emailService).sendShadowingApprovedEmail(
+                eq("shadower@example.com"),
+                eq("Java Interview - Unknown"),
+                any(),
+                any());
+    }
+
+    @Test
+    void approveShadowingRequest_withCandidate_usesCandidateNameInEmail() {
+        Candidate candidate = candidateRepository.save(
+                new Candidate(null, "Jane Doe", "jane@example.com", null, null, null));
+        interview.setCandidate(candidate);
+        interview = interviewRepository.save(interview);
+
+        ShadowingRequest request = shadowingRequestService.requestShadowing(interview.getId(), shadower.getId());
+        shadowingRequestService.approveShadowingRequest(request.getId(), interviewer.getId());
+
+        verify(emailService).sendShadowingApprovedEmail(
+                eq("shadower@example.com"),
+                eq("Java Interview - Jane Doe"),
+                any(),
+                any());
+    }
+
+    @Test
+    void approveShadowingRequest_sendsApprovalEmail() {
+        ShadowingRequest request = shadowingRequestService.requestShadowing(interview.getId(), shadower.getId());
+
+        shadowingRequestService.approveShadowingRequest(request.getId(), interviewer.getId());
+
+        verify(emailService).sendShadowingApprovedEmail(
+                eq("shadower@example.com"),
+                contains("Java"),
+                any(),
+                any());
     }
 }


### PR DESCRIPTION
## Summary
- **Resend SDK migration**: Replaced JavaMailSender/SMTP with Resend Java SDK for email delivery
- **Interview notification emails**: Send Resend emails on interview creation, update, and cancellation
- **Shadowing request approval emails**: Notify shadowers via email when their request is approved
- **Calendar 403 fix**: Use `sendUpdates=none` on service account calendar operations to avoid 403 errors
- **Auth interceptor fix**: Skip Authorization header on `/auth/` endpoints and restrict to backend-origin paths only
- **Shared calendar refactor**: Switch from delegation-based to shared service account calendar model
- **CI migration step**: Auto-apply Supabase migrations in deploy pipeline
- **Security fixes**: Guard user deletion, generic error messages, shuffle temp passwords, propagate email failures

## Test plan
- [ ] Verify interview CRUD creates/updates/deletes calendar events without 403
- [ ] Verify email notifications sent on interview create/update/cancel
- [ ] Verify email sent on shadowing request approval
- [ ] Verify login/register flows work without spurious 401s
- [ ] Verify CI pipeline runs migrations before deploy
- [ ] Run full test suite: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)