### PR TITLE
Release: Cloud Tasks audience config, gRPC fix, email queue & shared calendar

### DIFF
--- a/infra/cloudrun.py
+++ b/infra/cloudrun.py
@@ -84,6 +84,10 @@ backend_service = gcp.cloudrunv2.Service(
                         name="CLOUD_TASKS_SA_EMAIL",
                         value=cloudrun_sa.email,
                     ),
+                    gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                        name="CLOUD_TASKS_AUDIENCE",
+                        value=pulumi.Output.concat("https://", backend_domain),
+                    ),
                 ],
                 resources=gcp.cloudrunv2.ServiceTemplateContainerResourcesArgs(
                     limits={"memory": "1Gi", "cpu": "1000m"},

--- a/src/main/java/com/gm2dev/interview_hub/config/CloudTasksConfig.java
+++ b/src/main/java/com/gm2dev/interview_hub/config/CloudTasksConfig.java
@@ -1,18 +1,44 @@
 package com.gm2dev.interview_hub.config;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.tasks.v2.CloudTasksClient;
+import com.google.cloud.tasks.v2.CloudTasksSettings;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
+@Slf4j
 public class CloudTasksConfig {
 
     @Bean
     @ConditionalOnProperty(name = "app.cloud-tasks.enabled", havingValue = "true")
-    public CloudTasksClient cloudTasksClient() throws IOException {
-        return CloudTasksClient.create();
+    public CloudTasksClient cloudTasksClient(GoogleServiceAccountProperties saProperties) throws IOException {
+        final GoogleCredentials credentials = resolveCredentials(saProperties);
+        CloudTasksSettings settings = CloudTasksSettings.newBuilder()
+                .setCredentialsProvider(() -> credentials)
+                .build();
+        return CloudTasksClient.create(settings);
+    }
+
+    private GoogleCredentials resolveCredentials(GoogleServiceAccountProperties saProperties) throws IOException {
+        try {
+            GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+            log.info("Using Application Default Credentials for Cloud Tasks client");
+            return credentials;
+        } catch (IOException e) {
+            if (saProperties.getKeyJson() != null && !saProperties.getKeyJson().isBlank()) {
+                log.info("ADC not available, using service account key for Cloud Tasks client");
+                return ServiceAccountCredentials.fromStream(
+                        new ByteArrayInputStream(saProperties.getKeyJson().getBytes(StandardCharsets.UTF_8)));
+            }
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/gm2dev/interview_hub/service/EmailQueueService.java
+++ b/src/main/java/com/gm2dev/interview_hub/service/EmailQueueService.java
@@ -1,7 +1,7 @@
 package com.gm2dev.interview_hub.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import com.gm2dev.interview_hub.config.CloudTasksProperties;
 import com.gm2dev.interview_hub.dto.EmailTaskPayload;
 import com.google.cloud.tasks.v2.CloudTasksClient;
@@ -49,12 +49,13 @@ public class EmailQueueService {
                     .putHeaders("Content-Type", "application/json")
                     .setBody(ByteString.copyFrom(jsonPayload, StandardCharsets.UTF_8));
 
-            if (properties.serviceAccountEmail() != null && !properties.serviceAccountEmail().isBlank()) {
-                httpRequestBuilder.setOidcToken(
-                        OidcToken.newBuilder()
-                                .setServiceAccountEmail(properties.serviceAccountEmail())
-                                .build()
-                );
+            if (properties.hasValidServiceAccountEmail()) {
+                OidcToken.Builder oidcBuilder = OidcToken.newBuilder()
+                        .setServiceAccountEmail(properties.serviceAccountEmail());
+                if (properties.hasValidAudience()) {
+                    oidcBuilder.setAudience(properties.audience());
+                }
+                httpRequestBuilder.setOidcToken(oidcBuilder.build());
             }
 
             Task task = Task.newBuilder()
@@ -64,7 +65,7 @@ public class EmailQueueService {
             Task created = cloudTasksClient.createTask(properties.queuePath(), task);
             log.debug("Queued email task {} for {}", created.getName(), payload.to());
 
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("Failed to serialize email payload for {}", payload.to(), e);
             throw new RuntimeException("Failed to queue email", e);
         }

--- a/src/test/java/com/gm2dev/interview_hub/service/EmailQueueServiceTest.java
+++ b/src/test/java/com/gm2dev/interview_hub/service/EmailQueueServiceTest.java
@@ -1,6 +1,6 @@
 package com.gm2dev.interview_hub.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.gm2dev.interview_hub.config.CloudTasksProperties;
 import com.gm2dev.interview_hub.dto.EmailTaskPayload;
 import com.google.cloud.tasks.v2.CloudTasksClient;
@@ -73,6 +73,8 @@ class EmailQueueServiceTest {
         Task task = taskCaptor.getValue();
         assertThat(task.getHttpRequest().getOidcToken().getServiceAccountEmail())
                 .isEqualTo("sa@test-project.iam.gserviceaccount.com");
+        assertThat(task.getHttpRequest().getOidcToken().getAudience())
+                .isEqualTo("http://localhost:8080");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Cloud Tasks Integration**: Add OIDC audience configuration and improved credential resolution with ADC fallback to service account key
- **gRPC Version Fix**: Resolve backend startup crash caused by split gRPC versions
- **Email Queue System**: Async email sending via Google Cloud Tasks with OIDC token validation
- **Shared Calendar**: Switch from user OAuth to shared service account calendar model
- **Resend SDK Migration**: Replace JavaMailSender with Resend SDK for email delivery
- **Auth Interceptor**: Skip Authorization header on /auth/ endpoints to prevent 401 on public routes
- **GitHub Templates**: Add PR template and issue templates (feature request, bug report, chore)
- **Documentation**: Updates to CLAUDE.md, AGENTS.md, and infrastructure docs

## Related Issue

Closes multiple PRs merged to main:
- #58 (gRPC version split startup crash)
- #56 (email queue feature)
- #50 (calendar 403 fix & Resend notifications)
- #47 (Resend SDK migration)
- #44 (auth interceptor fix)
- #40 (shared calendar)

## Test Plan

- Backend tests pass (`./gradlew test`)
- JaCoCo coverage verification passes
- Cloud Tasks integration tested with audience configuration
- Email queue functionality verified
- Shared calendar operations validated

## Checklist
- [x] Tests pass (`./gradlew test` / `bun run test`)
- [x] Migration added (if schema changed)
- [x] No secrets committed