### PR TITLE
fix: enable RLS on all public tables

### DIFF
--- a/supabase/migrations/008_enable_rls_all_tables.sql
+++ b/supabase/migrations/008_enable_rls_all_tables.sql
@@ -1,0 +1,10 @@
+-- Enable Row Level Security on all public tables
+-- The app connects via JDBC as the postgres role (superuser), which bypasses RLS.
+-- This migration blocks access through Supabase's PostgREST API (anon/authenticated roles)
+-- without affecting the Spring Boot backend.
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.interviews ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shadowing_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.candidates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.verification_tokens ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Enables Row Level Security on all 5 public tables (`profiles`, `interviews`, `shadowing_requests`, `candidates`, `verification_tokens`) with no permissive policies
- Blocks unauthorized access through Supabase's auto-generated PostgREST API while the Spring Boot JDBC connection (postgres role) bypasses RLS unaffected
- Addresses Supabase Security Advisor warnings including **Sensitive Columns Exposed** on `verification_tokens` (account takeover vector)

## Test plan
- [ ] Apply migration to a staging/test Supabase project
- [ ] Verify the Security Advisor no longer flags RLS or sensitive column issues
- [ ] Confirm the Spring Boot backend can still read/write all tables normally
- [ ] Verify PostgREST API calls with `anon` key are denied on all tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)